### PR TITLE
Add GpuOnDeviceEventReceiver and GpuOnDeviceEventCollector.

### DIFF
--- a/third_party/xla/xla/backends/profiler/gpu/BUILD
+++ b/third_party/xla/xla/backends/profiler/gpu/BUILD
@@ -544,6 +544,84 @@ cc_library(
 )
 
 cc_library(
+    name = "ondevice_trace_events",
+    hdrs = ["ondevice_trace_events.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_library(
+    name = "ondevice_event_collector",
+    srcs = ["ondevice_event_collector.cc"],
+    hdrs = ["ondevice_event_collector.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cupti_buffer_events",
+        ":ondevice_trace_events",
+        "//xla/tsl/profiler/utils:lock_free_queue",
+        "//xla/tsl/profiler/utils:trace_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "//xla/tsl/profiler/utils:xplane_utils",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@local_tsl//tsl/platform:thread_annotations",
+        "@local_tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+cc_library(
+    name = "ondevice_event_receiver",
+    srcs = ["ondevice_event_receiver.cc"],
+    hdrs = ["ondevice_event_receiver.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ondevice_event_collector",
+        ":ondevice_trace_events",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/synchronization",
+        "@local_tsl//tsl/platform:thread_annotations",
+    ],
+)
+
+xla_cc_test(
+    name = "ondevice_event_collector_test",
+    srcs = ["ondevice_event_collector_test.cc"],
+    tags = [
+        "cuda-only",
+        "gpu",
+        "no_mac",
+    ],
+    deps = [
+        ":ondevice_event_collector",
+        ":ondevice_event_receiver",
+        ":ondevice_trace_events",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "@com_google_googletest//:gtest_main",
+        "@local_tsl//tsl/platform:test",
+        "@local_tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+cc_library(
     name = "cupti_status",
     srcs = ["cupti_status.cc"],
     hdrs = ["cupti_status.h"],

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector.cc
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector.cc
@@ -1,0 +1,262 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/ondevice_event_collector.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/profiler/gpu/cupti_buffer_events.h"
+#include "xla/backends/profiler/gpu/ondevice_trace_events.h"
+#include "xla/tsl/profiler/utils/lock_free_queue.h"
+#include "xla/tsl/profiler/utils/trace_utils.h"
+#include "xla/tsl/profiler/utils/xplane_builder.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"
+#include "xla/tsl/profiler/utils/xplane_utils.h"
+#include "tsl/platform/thread_annotations.h"
+
+using ::tensorflow::profiler::XPlane;
+using ::tensorflow::profiler::XSpace;
+using ::tsl::profiler::XEventBuilder;
+using ::tsl::profiler::XEventMetadata;
+using ::tsl::profiler::XLineBuilder;
+using ::tsl::profiler::XPlaneBuilder;
+
+namespace xla {
+namespace profiler {
+
+namespace {
+
+class EventQueueWithStringSilo {
+ public:
+  using EventQueue = ::tsl::profiler::BlockedQueue<GpuOnDeviceTraceEvent>;
+
+  void Clear() {
+    absl::MutexLock lock(&m_);
+    string_silo_.Clear();
+    events_.Clear();
+  }
+
+  void AddEvent(GpuOnDeviceTraceEvent&& event);
+
+  absl::flat_hash_map<int64_t, EventQueue> GroupPerInstanceEvents();
+
+ private:
+  absl::Mutex m_;
+  StringDeduper string_silo_ TF_GUARDED_BY(m_);
+  EventQueue events_ TF_GUARDED_BY(m_);
+};
+
+using EventQueue = EventQueueWithStringSilo::EventQueue;
+
+void EventQueueWithStringSilo::AddEvent(GpuOnDeviceTraceEvent&& event) {
+  absl::MutexLock lock(&m_);
+  event.tag_name = string_silo_.Dedup(event.tag_name);
+  events_.Push(std::move(event));
+}
+
+absl::flat_hash_map<int64_t, EventQueue>
+EventQueueWithStringSilo::GroupPerInstanceEvents() {
+  absl::flat_hash_map<int64_t, EventQueue> grouped;
+  // Note: after GroupPerDeviceEvents, the events_ is empty.
+  absl::MutexLock lock(&m_);
+  for (std::optional<GpuOnDeviceTraceEvent> event = events_.Pop();
+       event.has_value(); event = events_.Pop()) {
+    grouped[event->injection_instance_id].Push(std::move(event.value()));
+  }
+  return grouped;
+}
+
+class OndeviceLineIdAllocator {
+ public:
+  int64_t operator()(uint32_t pid, uint32_t tid) {
+    uint64_t key = Key(pid, tid);
+    auto it = to_line_id_.find(key);
+    if (it != to_line_id_.end()) {
+      return it->second;
+    }
+    int64_t line_id = to_line_id_.size();
+    to_line_id_[key] = line_id;
+    return line_id;
+  }
+
+ private:
+  uint64_t Key(uint32_t pid, uint32_t tid) {
+    return static_cast<uint64_t>(pid) << 32 | tid;
+  }
+
+  absl::flat_hash_map<uint64_t, int64_t> to_line_id_;
+};
+
+class GpuOnDeviceTraceEventCollectorImpl final
+    : public GpuOnDeviceTraceEventCollector {
+ public:
+  GpuOnDeviceTraceEventCollectorImpl(
+      const GpuOnDeviceTraceEventCollectorOptions& options,
+      uint64_t start_walltime_ns, uint64_t start_gputime_ns)
+      : options_(options),
+        start_walltime_ns_(start_walltime_ns),
+        start_gputime_ns_(start_gputime_ns) {}
+
+  ~GpuOnDeviceTraceEventCollectorImpl() override = default;
+
+  absl::Status Export(XSpace* space, uint64_t end_gpu_ns) override;
+
+  absl::Status AddEvent(GpuOnDeviceTraceEvent&& event) override;
+
+  absl::Status AddEvent(std::vector<GpuOnDeviceTraceEvent> events) override;
+
+  const GpuOnDeviceTraceEventCollectorOptions& options() const override {
+    return options_;
+  };
+
+  void CreateXEvent(GpuOnDeviceTraceEvent& event, XPlaneBuilder* plane,
+                    XLineBuilder* line, int64_t adjust_time_ns);
+
+  size_t FlushPerInstanceEvents(uint32_t instance_id, uint64_t end_gpu_ns,
+                                XSpace* space);
+
+  const GpuOnDeviceTraceEventCollectorOptions options_;
+  uint64_t start_walltime_ns_;
+  uint64_t start_gputime_ns_;
+  EventQueueWithStringSilo all_events_ = {};
+  absl::flat_hash_map<int64_t, EventQueue> instance_events_ = {};
+};
+
+void GpuOnDeviceTraceEventCollectorImpl::CreateXEvent(
+    GpuOnDeviceTraceEvent& event, XPlaneBuilder* plane, XLineBuilder* line,
+    int64_t adjust_time_ns) {
+  XEventMetadata* event_metadata =
+      plane->GetOrCreateEventMetadata(event.tag_name);
+  XEventBuilder xevent = line->AddEvent(*event_metadata);
+  xevent.SetTimestampNs(event.start_time_ns + adjust_time_ns);
+  xevent.SetDurationPs(static_cast<int64_t>(event.duration_ps));
+}
+
+size_t GpuOnDeviceTraceEventCollectorImpl::FlushPerInstanceEvents(
+    uint32_t instance_id, uint64_t end_gpu_ns, XSpace* space) {
+  // Create a plane for each instance.
+  if (instance_id >= ::tsl::profiler::kNumGpuOnDeviceCustomPlanesPerHost) {
+    LOG(WARNING) << "Instance id " << instance_id
+                 << " is larger than kNumGpuOnDeviceCustomPlanesPerHost("
+                 << ::tsl::profiler::kNumGpuOnDeviceCustomPlanesPerHost << ")";
+    return 0;
+  }
+
+  auto& events = instance_events_[instance_id];
+  // As uint32 is used for the mosaic event time, no absolute time could be
+  // calculated. So we use the earliest time stamp for this instance to align
+  // with the collector start time. Note such alignment only happens when the
+  // earliest time less than the collector start time.
+  int64_t earliest_time_ns = std::numeric_limits<int64_t>::max();
+  for (auto it = events.begin(), ite = events.end(); it != ite; ++it) {
+    earliest_time_ns = std::min(earliest_time_ns, it->start_time_ns);
+  }
+  int64_t adjust_time_ns =
+      static_cast<int64_t>(start_gputime_ns_) <= earliest_time_ns
+          ? 0
+          : static_cast<int64_t>(start_gputime_ns_) - earliest_time_ns;
+
+  std::string plane_name =
+      ::tsl::profiler::GpuOnDeviceTracePlaneName(instance_id);
+  XPlane* plane =
+      ::tsl::profiler::FindOrAddMutablePlaneWithName(space, plane_name);
+  plane->set_id(::tsl::profiler::kFirstGpuOnDeviceCustomPlaneId + instance_id);
+  XPlaneBuilder plane_builder(plane);
+
+  size_t num_events = 0;
+  OndeviceLineIdAllocator line_id_allocator;
+  for (auto it = events.begin(), ite = events.end(); it != ite; ++it) {
+    auto& event = *it;
+    int64_t line_id = line_id_allocator(event.pid, event.tid);
+    if (line_id < 0) {
+      LOG_EVERY_N(WARNING, 32)
+          << "No line ids available for pid #" << event.pid << ", tid #"
+          << event.tid << " in plane:" << plane_name;
+      continue;
+    }
+    XLineBuilder line = plane_builder.GetOrCreateLine(line_id);
+    if (line.Name().empty()) {
+      line.SetName(absl::StrFormat("PID#%9u, TID#%9u", it->pid, it->tid));
+      line.SetTimestampNs(start_gputime_ns_);
+    }
+    CreateXEvent(event, &plane_builder, &line, adjust_time_ns);
+    num_events++;
+  }
+  events.Clear();
+  return num_events;
+}
+
+}  // namespace
+
+absl::Status GpuOnDeviceTraceEventCollectorImpl::Export(XSpace* space,
+                                                        uint64_t end_gpu_ns) {
+  instance_events_ = all_events_.GroupPerInstanceEvents();
+  for (auto& [instance_id, events] : instance_events_) {
+    FlushPerInstanceEvents(instance_id, end_gpu_ns, space);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status GpuOnDeviceTraceEventCollectorImpl::AddEvent(
+    GpuOnDeviceTraceEvent&& event) {
+  if (event.injection_instance_id > options_.max_injection_instance) {
+    LOG_FIRST_N(WARNING, 32) << "Injection instance id "
+                             << event.injection_instance_id << " is too large.";
+    return absl::InvalidArgumentError("Injection instance id is too large.");
+  }
+  if (event.pid >= options_.max_pid) {
+    LOG_FIRST_N(WARNING, 32) << "Pid " << event.pid << " is too large.";
+    return absl::InvalidArgumentError("Pid is too large.");
+  }
+  if (event.tid >= options_.max_tid) {
+    LOG_FIRST_N(WARNING, 32) << "Tid " << event.tid << " is too large.";
+    return absl::InvalidArgumentError("Tid is too large.");
+  }
+  all_events_.AddEvent(std::move(event));
+  return absl::OkStatus();
+}
+
+absl::Status GpuOnDeviceTraceEventCollectorImpl::AddEvent(
+    std::vector<GpuOnDeviceTraceEvent> events) {
+  for (auto& event : events) {
+    AddEvent(std::move(event)).IgnoreError();
+  }
+  events.clear();
+  return absl::OkStatus();
+}
+
+std::unique_ptr<GpuOnDeviceTraceEventCollector>
+CreateGpuOnDeviceTraceEventCollector(
+    const GpuOnDeviceTraceEventCollectorOptions& options,
+    uint64_t start_walltime_ns, uint64_t start_gputime_ns) {
+  return std::make_unique<GpuOnDeviceTraceEventCollectorImpl>(
+      options, start_walltime_ns, start_gputime_ns);
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector.h
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector.h
@@ -1,0 +1,58 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_COLLECTOR_H_
+#define XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_COLLECTOR_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "xla/backends/profiler/gpu/ondevice_trace_events.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+
+struct GpuOnDeviceTraceEventCollectorOptions {
+  uint32_t max_injection_instance = 0;  // 0 to disable injection
+  uint32_t max_pid = 0xFFFFFFFF;        // 2^32 - 1
+  uint32_t max_tid = 0xFFFFFFFF;        // 2^32 - 1
+};
+
+class GpuOnDeviceTraceEventCollector {
+ public:
+  virtual ~GpuOnDeviceTraceEventCollector() = default;
+
+  virtual absl::Status Export(::tensorflow::profiler::XSpace* space,
+                              uint64_t end_gpu_ns) = 0;
+
+  virtual absl::Status AddEvent(GpuOnDeviceTraceEvent&& event) = 0;
+
+  virtual absl::Status AddEvent(std::vector<GpuOnDeviceTraceEvent> events) = 0;
+
+  virtual const GpuOnDeviceTraceEventCollectorOptions& options() const = 0;
+};
+
+std::unique_ptr<GpuOnDeviceTraceEventCollector>
+CreateGpuOnDeviceTraceEventCollector(
+    const GpuOnDeviceTraceEventCollectorOptions& options,
+    uint64_t start_walltime_ns, uint64_t start_gputime_ns);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_COLLECTOR_H_

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector_test.cc
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_event_collector_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/ondevice_event_collector.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "xla/backends/profiler/gpu/ondevice_event_receiver.h"
+#include "xla/backends/profiler/gpu/ondevice_trace_events.h"
+
+namespace xla {
+namespace profiler {
+namespace test {
+
+namespace {
+
+TEST(GpuOnDeviceTraceEventCollectorTest, SimpleInjection) {
+  std::unique_ptr<GpuOnDeviceTraceEventCollector> collector =
+      CreateGpuOnDeviceTraceEventCollector(
+          {.max_injection_instance = 5, .max_pid = 10, .max_tid = 10}, 0, 0);
+  auto* receiver = GpuOnDeviceTraceEventReceiver::GetSingleton();
+  ASSERT_EQ(receiver->ActiveVersion(), 0);
+
+  ASSERT_OK_AND_ASSIGN(size_t version, receiver->StartWith(collector.get()));
+  ASSERT_NE(version, 0);
+
+  uint32_t wrong_version_injection =
+      receiver->StartInjectionInstance(version + 100);
+  ASSERT_EQ(wrong_version_injection, 0);
+
+  uint32_t instance_id = receiver->StartInjectionInstance(version);
+  ASSERT_NE(instance_id, 0);
+
+  GpuOnDeviceTraceEvent event{
+      .injection_instance_id = instance_id,
+      .tag_name = "test_tag",
+      .pid = 1,
+      .tid = 1,
+      .start_time_ns = 10,
+      .duration_ps = 10000,
+  };
+  ASSERT_OK(receiver->Inject(version, std::move(event)));
+
+  GpuOnDeviceTraceEvent event_wrong_instance_id{
+      .injection_instance_id = instance_id + 10,
+      .tag_name = "wrong_instance_id",
+      .pid = 1,
+      .tid = 1,
+      .start_time_ns = 20,
+      .duration_ps = 10000,
+  };
+  auto status = receiver->Inject(version, std::move(event_wrong_instance_id));
+  ASSERT_FALSE(status.ok());
+  ASSERT_EQ(status.message(), "Injection instance id is out of range.");
+
+  ASSERT_OK(receiver->Stop());
+}
+
+}  // namespace
+
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_event_receiver.cc
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_event_receiver.cc
@@ -1,0 +1,109 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/ondevice_event_receiver.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/profiler/gpu/ondevice_event_collector.h"
+#include "xla/backends/profiler/gpu/ondevice_trace_events.h"
+
+namespace xla {
+namespace profiler {
+
+GpuOnDeviceTraceEventReceiver* GpuOnDeviceTraceEventReceiver::GetSingleton() {
+  static GpuOnDeviceTraceEventReceiver* receiver =
+      new GpuOnDeviceTraceEventReceiver();
+  return receiver;
+}
+
+size_t GpuOnDeviceTraceEventReceiver::ActiveVersion() {
+  absl::MutexLock lock(&mutex_);
+  return (collector_ != nullptr) ? version_ : 0;
+}
+
+absl::Status GpuOnDeviceTraceEventReceiver::Inject(
+    size_t version, std::vector<GpuOnDeviceTraceEvent> events) {
+  absl::MutexLock lock(&mutex_);
+  if (collector_ != nullptr && version == version_) {
+    return collector_->AddEvent(std::move(events));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status GpuOnDeviceTraceEventReceiver::Inject(
+    size_t version, GpuOnDeviceTraceEvent&& event) {
+  absl::MutexLock lock(&mutex_);
+  if (collector_ != nullptr && version == version_) {
+    if (event.injection_instance_id > current_injection_id_) {
+      return absl::InternalError("Injection instance id is out of range.");
+    }
+    return collector_->AddEvent(std::move(event));
+  }
+  return collector_ == nullptr
+             ? absl::InternalError("Can not inject to nullptr collector.")
+             : absl::InternalError("Inject with mismatched version!");
+}
+
+absl::StatusOr<size_t> GpuOnDeviceTraceEventReceiver::StartWith(
+    GpuOnDeviceTraceEventCollector* collector) {
+  if (collector == nullptr) {
+    return absl::InternalError("Can not bind nullptr collector.");
+  }
+  if (collector->options().max_injection_instance == 0) {
+    return absl::InternalError("Can not bind collector disabled injection");
+  }
+  absl::MutexLock lock(&mutex_);
+  if (collector_ != nullptr && collector_ != collector) {
+    return absl::InternalError(
+        "GpuOnDeviceTraceEventReceiver already bind with another collector.");
+  }
+  if (collector_ == nullptr) {
+    version_++;
+    current_injection_id_ = 0;
+    collector_ = collector;
+    max_injection_instance_ = collector->options().max_injection_instance;
+  }
+  return version_;
+}
+
+// Return and increment the injection instance id if successful.
+uint32_t GpuOnDeviceTraceEventReceiver::StartInjectionInstance(
+    uint32_t version) {
+  absl::MutexLock lock(&mutex_);
+  if (collector_ == nullptr || version != version_ ||
+      current_injection_id_ >= max_injection_instance_) {
+    return 0;
+  }
+  return ++current_injection_id_;
+}
+
+absl::Status GpuOnDeviceTraceEventReceiver::Stop() {
+  absl::MutexLock lock(&mutex_);
+  if (collector_ != nullptr) {
+    collector_ = nullptr;
+    version_++;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_event_receiver.h
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_event_receiver.h
@@ -1,0 +1,86 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_RECEIVER_H_
+#define XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_RECEIVER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/profiler/gpu/ondevice_event_collector.h"
+#include "xla/backends/profiler/gpu/ondevice_trace_events.h"
+#include "tsl/platform/thread_annotations.h"
+
+namespace xla {
+namespace profiler {
+
+//     GpuOnDeviceTraceEventReceiver is a singleton class that receives
+// GpuOnDeviceTraceEvent(s). Parallel threads may postprocess hardware event
+// buffer (may be dumped into host memory) and inject those software generated
+// event(s) to this Receiver. It will be global available to users by its APIs,
+// or Python bindings, to a) check if it is active (in some profiling session);
+// b) inject events that user software generated.
+//     Upon receiving the event(s), the receiver will forward the event(s) to
+// the collector (if not nullptr) of type GpuOnDeviceTraceEventCollector.
+// The Collector registers itself to this receiver by callingStartWith(), so
+// that it cold receive the event(s) from the receiver upon user injection.
+//     Note that the collector could be wrapped by a profiler which follows
+// profiler api, so that it will be created together with other profilers
+// at the beginning of a session, and be destroyed at the end of the session.
+class GpuOnDeviceTraceEventReceiver final {
+ public:
+  static GpuOnDeviceTraceEventReceiver* GetSingleton();
+
+  // Returns non-zero version number if the there has a collector bound
+  // to this receiver. Otherwise, returns zero. A version number is uniquely
+  // assigned to each collector when it is bound to this receiver in the
+  // StartWith() call.
+  size_t ActiveVersion();
+
+  // Return and increment the injection instance id if the version matches.
+  uint32_t StartInjectionInstance(uint32_t version);
+
+  absl::Status Inject(size_t version,
+                      std::vector<GpuOnDeviceTraceEvent> events);
+
+  absl::Status Inject(size_t version, GpuOnDeviceTraceEvent&& event);
+
+  // Return active version number if collector is successfully bound to this
+  // receiver. Otherwise, error status.
+  absl::StatusOr<size_t> StartWith(GpuOnDeviceTraceEventCollector* collector);
+
+  absl::Status Stop();
+
+ private:
+  GpuOnDeviceTraceEventReceiver() = default;
+  GpuOnDeviceTraceEventReceiver(const GpuOnDeviceTraceEventReceiver&) = delete;
+  GpuOnDeviceTraceEventReceiver& operator=(
+      const GpuOnDeviceTraceEventReceiver&) = delete;
+
+  uint32_t max_injection_instance_ = 8;
+  absl::Mutex mutex_;
+  uint32_t current_injection_id_ TF_GUARDED_BY(mutex_) = 0;
+  size_t version_ TF_GUARDED_BY(mutex_) = 0;
+  GpuOnDeviceTraceEventCollector* collector_ TF_GUARDED_BY(mutex_) = nullptr;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ONDEVICE_EVENT_RECEIVER_H_

--- a/third_party/xla/xla/backends/profiler/gpu/ondevice_trace_events.h
+++ b/third_party/xla/xla/backends/profiler/gpu/ondevice_trace_events.h
@@ -1,0 +1,40 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ONDEVICE_TRACE_EVENTS_H_
+#define XLA_BACKENDS_PROFILER_GPU_ONDEVICE_TRACE_EVENTS_H_
+
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+
+namespace xla {
+namespace profiler {
+
+struct GpuOnDeviceTraceEvent {
+  // One injection instance mapping to a single kernel execution.
+  uint32_t injection_instance_id = 0;
+  absl::string_view tag_name = "";
+  uint32_t tag_id = 0;
+  uint32_t pid = 0;
+  uint32_t tid = 0;
+  int64_t start_time_ns = 0;
+  int64_t duration_ps = 0;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ONDEVICE_TRACE_EVENTS_H_

--- a/third_party/xla/xla/tsl/profiler/utils/trace_utils.h
+++ b/third_party/xla/xla/tsl/profiler/utils/trace_utils.h
@@ -47,6 +47,12 @@ constexpr uint32 kFirstNcclPlaneId =
     tsl::profiler::kMaxCustomPlaneDevicesPerHost - kMaxNcclPlanes;
 constexpr uint32 kLastNcclPlaneId = kFirstNcclPlaneId + kMaxNcclPlanes - 1;
 
+constexpr int kNumGpuOnDeviceCustomPlanesPerHost = 50;
+constexpr int kFirstGpuOnDeviceCustomPlaneId =
+    kFirstNcclPlaneId - kNumGpuOnDeviceCustomPlanesPerHost;
+constexpr int kLastGpuOnDeviceCustomPlaneId =
+    kFirstGpuOnDeviceCustomPlaneId + kNumGpuOnDeviceCustomPlanesPerHost - 1;
+
 // Constants used as trace_viewer TID (resource_id in trace_events.proto).
 constexpr int kThreadIdDerivedMin = 0xdeadbeef;
 constexpr int kThreadIdStepInfo = kThreadIdDerivedMin;

--- a/third_party/xla/xla/tsl/profiler/utils/xplane_schema.cc
+++ b/third_party/xla/xla/tsl/profiler/utils/xplane_schema.cc
@@ -37,6 +37,8 @@ const char kSparseCorePlaneRegex[] = {
 // TODO(b/195582092): change it to /device:custom once all literals are
 // migrated.
 const absl::string_view kCustomPlanePrefix = "/device:CUSTOM:";
+const absl::string_view kCustomGpuOnDeviceTracePlanePrefix =
+    "/device:CUSTOM:MOSAIC:";  // /device:CUSTOM:MOSAIC:INSTANCE_ID
 
 const absl::string_view kScopeRangeIdTreePlaneName =
     "/host:__ScopeRangeCallStack__";

--- a/third_party/xla/xla/tsl/profiler/utils/xplane_schema.h
+++ b/third_party/xla/xla/tsl/profiler/utils/xplane_schema.h
@@ -66,6 +66,8 @@ TF_CONST_INIT extern const absl::string_view kHostCpusPlaneName;
 TF_CONST_INIT extern const absl::string_view kSyscallsPlaneName;
 // Name of XPlane that contains namescope stack tree.
 TF_CONST_INIT extern const absl::string_view kScopeRangeIdTreePlaneName;
+// Name prefix of XPlane that contains GPU on-device events.
+TF_CONST_INIT extern const absl::string_view kCustomGpuOnDeviceTracePlanePrefix;
 
 // Names of XLines that contain ML-level events.
 TF_CONST_INIT extern const absl::string_view kStepLineName;
@@ -425,6 +427,10 @@ inline std::string TpuPlaneName(int32_t device_ordinal) {
 
 inline std::string GpuPlaneName(int32_t device_ordinal) {
   return absl::StrCat(kGpuPlanePrefix, device_ordinal);
+}
+
+inline std::string GpuOnDeviceTracePlaneName(int32_t instance_id) {
+  return absl::StrCat(kCustomGpuOnDeviceTracePlanePrefix, instance_id);
 }
 
 absl::string_view GetHostEventTypeStr(HostEventType event_type);


### PR DESCRIPTION
GpuOnDeviceEventReceiver is a singleton that receives GpuOnDeviceEvent(s). It is public through c++ APIs or Python bindings, so that client can inject events. GpuOnDeviceEventCollector takes GpuOnDeviceTraceEvents from GpuOnDeviceEventReceiver, store and export them.

PiperOrigin-RevId: 789850935